### PR TITLE
fix(subscriptions): Make replication incremental

### DIFF
--- a/tap_chargify/chargify.py
+++ b/tap_chargify/chargify.py
@@ -41,7 +41,7 @@ class Chargify(object):
     uri = "{uri}{path}".format(uri=self.uri, path=path)
     has_more = True
     page = 1
-    per_page = 100
+    per_page = 200
     while has_more:
       params = {
         "page": page,

--- a/tap_chargify/chargify.py
+++ b/tap_chargify/chargify.py
@@ -113,7 +113,7 @@ class Chargify(object):
 
 
   def subscriptions(self, bookmark=None):
-    for i in self.get("subscriptions.json", start_datetime=bookmark, date_field="updated_at", direction="asc"):
+    for i in self.get("subscriptions.json", start_datetime=bookmark, date_field="updated_at", sort="updated_at", direction="asc"):
       for j in i:
         yield j["subscription"]
 

--- a/tap_chargify/streams.py
+++ b/tap_chargify/streams.py
@@ -102,13 +102,12 @@ class Stream():
         res = get_data(bookmark)
 
         if self.replication_method == "INCREMENTAL":
-            # These streams results may not be ordered,
-            # so store highest value bookmark in session.
+            # We make sure in the request to the Chargify API that all incremental streams are
+            # ordered and filtered to have only records newer than the bookmark
+            # All the records can then be returned
             for item in res:
-                # if item is bigger than bookmark, then
-                if self.is_bookmark_old(state, item[self.replication_key]):
-                    self.update_bookmark(state, item[self.replication_key])
-                    yield (self.stream, item)
+                self.update_bookmark(state, item[self.replication_key])
+                yield (self.stream, item)
         else:
             for item in res:
                 yield (self.stream, item)
@@ -148,8 +147,8 @@ class Components(Stream):
 
 class Subscriptions(Stream):
     name = "subscriptions"
-    replication_method = "FULL_TABLE"
-    # replication_key = "updated_at"
+    replication_method = "INCREMENTAL"
+    replication_key = "updated_at"
 
 
 class Transactions(Stream):


### PR DESCRIPTION
Is there any reason to have a FULL_TABLE replication for subscriptions? IMO it is much better to have an incremental replication method, this is fully supported by Chargify API (can be date or id based).
This PR provides an incremental replication. It has been tested with the big-query target.

fixes #35 
