### PR TITLE
Update components.json with component prices & additional fields

### DIFF
--- a/tap_chargify/schemas/components.json
+++ b/tap_chargify/schemas/components.json
@@ -124,6 +124,71 @@
         "string"
       ],
       "format": "date-time"
+    },
+    "default_price_point_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "product_family_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "prices": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "component_id": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "starting_quantity": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "ending_quantity": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "unit_price": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "price_point_id": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "formatted_unit_price": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
There are a handful of additional properties noted within [Chargify documentation](https://reference.chargify.com/v1/components/read-component) that could be useful for components. In particular, the `prices` JSON field would be very invaluable in improving information on pricing groups under special bundle offers. This new version of `components.json` was tested locally, and the additional fields were added with no clear errors appearing.

# Description of change
Adding additional properties to `components`

# Manual QA steps
Potentially re-run the following 2 commands to make sure the change was successfully implemented.

```
tap-chargify --config config.json --discover > catalog.json
tap-chargify --config config.json --catalog catalog.json
```
 
# Risks
 - n/a
 
# Rollback steps
 - revert this branch
