### PR TITLE
Adding `component_price_points` endpoint

### DIFF
--- a/tap_chargify/chargify.py
+++ b/tap_chargify/chargify.py
@@ -93,6 +93,16 @@ class Chargify(object):
             for o in self.get("products/{product_id}/price_points.json".format(product_id=l["product"]["id"])):
               for m in o["price_points"]:
                 yield m
+                
+                
+  def components_price_points(self, bookmark=None):
+  for i in self.get("product_families.json"):
+    for j in i:
+      for k in self.get("product_families/{product_family_id}/components.json".format(product_family_id=j["product_family"]["id"])):
+        for l in k:
+          for o in self.get("components/{component_id}/price_points.json".format(component_id=l["component"]["id"])):
+            for m in o["price_points"]:
+              yield m
 
 
   def coupons(self, bookmark=None):

--- a/tap_chargify/schemas/component_price_points.json
+++ b/tap_chargify/schemas/component_price_points.json
@@ -1,0 +1,109 @@
+{
+  "type": [
+    "null",
+    "object"
+  ],
+  "properties": {
+    "id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "default": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "pricing_scheme": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "component_id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "handle": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "archived_at": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "created_at": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "updated_at": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "prices": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "properties": {
+          "id": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "component_id": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "starting_quantity": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "ending_quantity": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "unit_price": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/tap_chargify/streams.py
+++ b/tap_chargify/streams.py
@@ -144,6 +144,11 @@ class Coupons(Stream):
 class Components(Stream):
     name = "components"
     replication_method = "FULL_TABLE"
+    
+    
+ class ComponentPricePoints(Stream):
+    name = "component_price_points"
+    replication_method = "FULL_TABLE"
 
 
 class Subscriptions(Stream):
@@ -187,6 +192,7 @@ STREAMS = {
     "price_points": PricePoints,
     "coupons": Coupons,
     "components": Components,
+    "component_price_points": ComponentPricePoints,
     "subscriptions": Subscriptions,
     "transactions": Transactions,
     "statements": Statements,


### PR DESCRIPTION
# Description of change
Adding endpoint for component price points. Current schemas only contain price points for products.

# Manual QA steps
 - Re-run Singer Tap to see if new endpoint is picked up
 
# Risks
 - Passed successfully during local testing, but would like another check before merging
 
# Rollback steps
 - revert this branch
