### PR TITLE
Update subscriptions.json

### DIFF
--- a/tap_chargify/schemas/subscriptions.json
+++ b/tap_chargify/schemas/subscriptions.json
@@ -316,8 +316,9 @@
         "portal_invite_last_accepted_at": {
           "type": [
             "null",
-            "number"
-          ]
+            "string"
+          ],
+          "format": "date-time"
         },
         "tax_exempt": {
           "type": [


### PR DESCRIPTION
Fix schema definition for customer resource on subscriptions

# Description of change
This replaces https://github.com/singer-io/tap-chargify/pull/46

This makes the customer resource on the `subscription` schema inline with the `customer` schema.

https://github.com/singer-io/tap-chargify/blob/master/tap_chargify/schemas/customers.json#L119C1-L125C7

The difference is `subscription.customer.portal_invite_last_accepted_at` was set to a number however the property on the customer is actually a date-time.

# Manual QA steps
 - 
 
# Risks
 - None, currently when running this tap you're unable to include the customer resource.
 
# Rollback steps
 - revert this branch

/cc @sgandhi1311 