### PR TITLE
Update testing infrastructure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,37 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester-uv
+    steps:
+      - checkout
+      - run:
+          name: 'Setup virtual env'
+          command: |
+            uv venv --python=3.9 /usr/local/share/virtualenvs/tap-chargify
+            source /usr/local/share/virtualenvs/tap-chargify/bin/activate
+            uv pip install -U pip setuptools
+            uv pip install .[dev]
+      - add_ssh_keys
+      - run:
+          name: 'JSON Validator'
+          command: |
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            stitch-validate-json /usr/local/share/virtualenvs/tap-chargify/lib/python3.9/site-packages/tap_chargify/schemas/*.json
+workflows:
+  version: 2
+  commit:
+    jobs:
+      - build:
+          context: circleci-user
+  build_daily:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - build:
+          context: circleci-user

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - run:
           name: 'Setup virtual env'
           command: |
-            uv venv --python=3.9 /usr/local/share/virtualenvs/tap-chargify
+            uv venv --python 3.9 /usr/local/share/virtualenvs/tap-chargify
             source /usr/local/share/virtualenvs/tap-chargify/bin/activate
             uv pip install -U pip setuptools
             uv pip install .[dev]


### PR DESCRIPTION
This PR updates the CircleCI config to use `uv` to create and manage virtualenvs and python dependencies